### PR TITLE
Fix windows

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -9,6 +9,7 @@
 	var path = require('path');
 	var AWS = require('aws-sdk');
 	var mime = require('mime');
+	var upath = require('upath');
 
 	var ignores = {
 		'.DS_Store': true
@@ -65,7 +66,7 @@
 			filepath = filepath.replace(publicDir, '').replace(/^\//, '');
 			s3.putObject({
 				Bucket: config.deploy.bucket,
-				Key: filepath,
+				Key: upath.toUnix(filepath),
 				Body: data,
 				ContentType: mimeType,
 				ACL: ACL_PUBLIC_READ

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -6,7 +6,6 @@
 	var ACL_PUBLIC_READ = 'public-read';
 
 	var fs = require('fs');
-	var path = require('path');
 	var AWS = require('aws-sdk');
 	var mime = require('mime');
 	var upath = require('upath');
@@ -32,7 +31,7 @@
 				if (isIgnored(file)) {
 					return;
 				}
-				file = path.join(filepath, file);
+				file = upath.join(filepath, file);
 				fs.stat(file, function (err, stats) {
 					if (err) {
 						console.log(err, err.stack);
@@ -57,7 +56,7 @@
 	module.exports = function () {
 		var config = this.config;
 		var baseDir = this.base_dir;
-		var publicDir = path.join(baseDir, config.public_dir);
+		var publicDir = upath.join(baseDir, config.public_dir);
 		var s3 = new AWS.S3({
 			region: config.deploy.region
 		});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "homepage": "https://github.com/kei-ito/hexo-deployer-aws-s3#readme",
   "dependencies": {
     "aws-sdk": "^2.1.35",
-    "mime": "^1.3.4"
+    "mime": "^1.3.4",
+    "upath": "^0.1.6"
   },
   "readme": "# hexo-deployer-aws-s3\nAWS S3 deployer plugin for [Hexo].\n\n## Installation\n\n``` bash\n$ npm install hexo-deployer-aws-s3 --save\n```\n\n## Setup\n\nWe must provide 4 parameters below to the AWS SDK.\n\n1. **accessKeyId**\n2. **secretAccessKey**\n3. **region**\n4. **bucket**\n\nYou can set **region** and **bucket** in `_config.yml`\n\n``` yaml\ndeploy:\n  type: aws-s3\n  region: <region>\n  bucket: <bucket>\n```\n\nYou can't set **accessKeyId** and **secretAccessKey** in this plugin. Instead, you can set them via global settings below.\n\n- Credentials File: `~/.aws/credentials`\n- Environment Variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`\n\nFor more, see [Configuring the SDK in Node.js].\n\n[Hexo]: http://hexo.io/\n[Configuring the SDK in Node.js]: http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html\n\n## Usage\n\n``` bash\n$ hexo deploy\n```\n\n## License\nMIT",
   "readmeFilename": "README.md",


### PR DESCRIPTION
This builds on top of the change by @gentooist and goes a step further by completely removing all usages of `path` and using `upath` instead.

This ensures files get uploaded to S3 with the proper file name on windows.
